### PR TITLE
Adicionando link da documentação no Leiame.org.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,6 @@
 [![Leiame.org](http://leiame.org/console/repos/brunogoncalves/docs/status)](http://leiame.org/console/repos/brunogoncalves/docs)
 
 Documentação do desenvolvimento
+
+
+Leia a documentação em: [http://code.leiame.org](http://code.leiame.org).


### PR DESCRIPTION
Senti falta desse link.
Como toda a documentação é feita pensando no Leiame.org, acho que é legal no repositório ter essa indicação.
